### PR TITLE
fix: globals in .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,20 +9,20 @@ const eslintConfig = {
 eslintConfig.parserOptions = {
 	ecmaVersion: 6,
 	env: {
-    jest: true,
-    es6: true
-  },
+		jest: true,
+		es6: true,
+	},
 	babelOptions: {
 		presets: [
 			'@wordpress/babel-preset-default',
 			'@babel/preset-typescript',
 		],
-    globals: {
-      page: true,
-      browser: true,
-      context: true,
-      jestPuppeteer: true,
-    },
+	},
+	globals: {
+		page: true,
+		browser: true,
+		context: true,
+		jestPuppeteer: true,
 	},
 };
 


### PR DESCRIPTION
While figuring out how to use this template, I found that the `globals` had accidentally been nested under the `babelOptions`. Also `prettier` reformatted the `env` section to match the rules.