### PR TITLE
Updates the repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 clone the project into your plugin folder:
 
 ```shell
-git clone https://github.com/erikyo/typescript-wp-block.git
+git clone https://github.com/your-username/typescript-wp-block.git
 ```
 Then: 
 - Rename the plugin folder with the chosen plugin name slug

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
 		"Erik Golinelli <erik@codekraft.it> (https://codekraft.it/)",
 		"John Hooks <bitmachina@outlook.com> (https://johnhooks.io/)"
 	],
-	"homepage": "https://github.com/erikyo/typescript-wp-block#readme",
+	"homepage": "https://github.com/wp-blocks/typescript-wp-block#readme",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/erikyo/typescript-wp-block.git"
+		"url": "https://github.com/wp-blocks/typescript-wp-block.git"
 	},
-	"bugs": "https://github.com/erikyo/typescript-wp-block/issues",
+	"bugs": "https://github.com/wp-blocks/typescript-wp-block/issues",
 	"license": "GPL-2.0-or-later",
 	"main": "./build/boilerplate.js",
 	"typings": "./build/main.d.ts",

--- a/typescript-wp-block.php
+++ b/typescript-wp-block.php
@@ -1,11 +1,13 @@
 <?php
 /**
  * Plugin Name: Typescript WP Block Boilerplate
- * Plugin URI: https://github.com/erikyo/typescript-wp-block
+ * Plugin URI: https://github.com/wp-blocks/typescript-wp-block
  * Description: WordPress block boilerplate in typescript
  * Version: 0.0.1
  * Author: codekraft
  */
+
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 add_action( 'init', function() {
 	register_block_type( __DIR__ );


### PR DESCRIPTION
I just realized it now but the package.json urls were still pointing the old repo
Additionally, recently I recently tried to publish a plugin but the plugin review team told me that I had to add this. it is better to do it in the template as well so that it is more "safe"